### PR TITLE
fix: pass constructor options to parent

### DIFF
--- a/src/KeyvLru.js
+++ b/src/KeyvLru.js
@@ -2,6 +2,13 @@
 
 import type { MapInterface } from '../flow/types/MapInterface';
 
+export type KeyvLruOptions = {
+  max: number,
+  notify?: boolean,
+  ttl?: number,
+  expire?: number,
+};
+
 const lru = require('tiny-lru');
 const EventEmitter = require('events');
 
@@ -13,14 +20,7 @@ class KeyvLru extends EventEmitter implements MapInterface {
   cache: Object;
   defaultTtl: ?number;
 
-  constructor(
-    options: {
-      max: number,
-      notify?: boolean,
-      ttl?: number,
-      expire?: number,
-    } = { max: 500 }
-  ) {
+  constructor(options: KeyvLruOptions = { max: 500 }) {
     super();
     this.defaultTtl = options.ttl;
     this.cache = lru(

--- a/src/KeyvLruManagedTtl.js
+++ b/src/KeyvLruManagedTtl.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type { ExpirableItem } from '../flow/types/ExpirableItem';
+import type { KeyvLruOptions } from './KeyvLru';
 
 const lru = require('tiny-lru');
 const KeyvLru = require('./KeyvLru');
@@ -21,14 +22,7 @@ class KeyvLruManagedTtl<T> extends KeyvLru {
   cache: Object;
   defaultTtl: ?number;
 
-  constructor(
-    options: {
-      max: number,
-      notify?: boolean,
-      ttl?: number,
-      expire?: number,
-    } = { max: 500 }
-  ) {
+  constructor(options: KeyvLruOptions = { max: 500 }) {
     super(options);
     this.cache = lru(options.max, options.notify);
   }

--- a/src/KeyvLruManagedTtl.js
+++ b/src/KeyvLruManagedTtl.js
@@ -26,9 +26,10 @@ class KeyvLruManagedTtl<T> extends KeyvLru {
       max: number,
       notify?: boolean,
       ttl?: number,
+      expire?: number,
     } = { max: 500 }
   ) {
-    super();
+    super(options);
     this.cache = lru(options.max, options.notify);
   }
 


### PR DESCRIPTION
This will make the KeyvLruManagedTtl parent aware of the options.